### PR TITLE
Using strchr() inside find_byte()

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -18,15 +18,12 @@ find_byte(char const *s, char ch) {
 #else
 int8_t
 find_byte(char const *s, char ch) {
-  int i;
+  char *p = memchr(s, ch, 16);
 
-  for(i = 0; i < 16; i++) {
-    if(s[i] == ch)
-      return i;
-    if(!s[i])
-      return -1;
-  }
-  return -1;
+  if (p == NULL)
+    return -1;
+  else
+    return p - s;
 }
 #endif
 


### PR DESCRIPTION
Currently, this function find_byte() implements a function that is similar to
strchr() provided by libc. Althought there is an optimized code Intel, SSE, it
lacks optimizations for other architectures, as IBM POWER8. Using strchr()
inside the find_byte() function, improves up to 20x the find_byte() performance
on non-SSE architectures, as IBM POWER8. That is because strchr() is usually
optimized already.